### PR TITLE
Update the README example to use Makie.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ Pkg.test("EarCut")
 
 Usage:
 ```Julia
-using EarCut
-using GeometryTypes
+using EarCut, GeometryBasics
 a = Circle(Point2f0(0), 0.5f0)
 b = Circle(Point2f0(0), 1f0)
 polygon = [decompose(Point2f0, b), decompose(Point2f0, a)] # some points defining a polygon. Must be a Vector{Vector{Point}}
 triangle_faces = triangulate(polygon)
-# then display with e.g. GLVisualize like this:
-using GLVisualize, Colors; w = glscreen(); @async renderloop(w)
+
+# then display with e.g. Makie like this:
+using Makie, Colors
+
 v = map(x-> Point3f0(x[1], x[2], 0), vcat(polygon...))
-mesh = GLNormalMesh(vertices=v, faces=triangle_faces)
-_view(visualize(mesh), camera = :orthographic_pixel)
-GLAbstraction.center!(w, :orthographic_pixel)
+msh = GLNormalMesh(vertices=v, faces=triangle_faces)
+
+scene = Makie.mesh(v, triangle_faces; color = 1:length(v), shading = false, scale_plot = false, show_axis = false)
 ```
 
 resulting in:
 
-
-![image](https://user-images.githubusercontent.com/1010467/34985721-569dc228-fab5-11e7-8557-66962cbc7a70.png)
+![image](https://user-images.githubusercontent.com/32143268/79715814-78497d00-82f2-11ea-958c-51b757fad7a0.png)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ triangle_faces = triangulate(polygon)
 # then display with e.g. Makie like this:
 using Makie, Colors
 
-v = map(x-> Point3f0(x[1], x[2], 0), vcat(polygon...))
-msh = GLNormalMesh(vertices=v, faces=triangle_faces)
+v = vcat(polygon...)
+msh = GeometryBasics.Mesh(v, triangle_faces)
 
 scene = Makie.mesh(v, triangle_faces; color = 1:length(v), shading = false, scale_plot = false, show_axis = false)
 ```


### PR DESCRIPTION
This replaces the old GLVisualize example with a Makie one, which I can verify works.

Incidentally, the GLNormalMesh call fails, so I replaced it.
```julia
 msh = GLNormalMesh(vertices=v, faces=triangle_faces)
ERROR: MethodError: no method matching AbstractArray{GeometryBasics.Ngon{Dim,Float32,3,PointMeta{Dim,Float32,Point{Dim,Float32},(:normals,),Tuple{Vec{3,Float32}}}},1} where Dim(; vertices=Point{3,Float32}[[1.2246469f-16, -1.0, 0.0], [-0.099567845, -0.99503076, 0.0], [-0.19814615, -0.9801725, 0.0], [-0.29475516, -0.9555728, 0.0], [-0.3884348, -0.9214762, 0.0], [-0.478254, -0.8782216, 0.0], [-0.56332004, -0.82623875, 0.0], [-0.64278764, -0.76604444, 0.0], [-0.71586686, -0.6982368, 0.0], [-0.7818315, -0.6234898, 0.0]  …  [0.39091575, -0.3117449, 0.0], [0.35793343, -0.3491184, 0.0], [0.32139382, -0.38302222, 0.0], [0.28166002, -0.41311938, 0.0], [0.239127, -0.4391108, 0.0], [0.1942174, -0.4607381, 0.0], [0.14737758, -0.4777864, 0.0], [0.099073075, -0.49008626, 0.0], [0.049783923, -0.49751538, 0.0], [1.8369701f-16, -0.5, 0.0]], faces=NgonFace{3,OffsetInteger{-1,UInt32}}[TriangleFace(OffsetInteger{-1,UInt32}(0x00000000), OffsetInteger{-1,UInt32}(0x0000003f), OffsetInteger{-1,UInt32}(0x0000003e)), TriangleFace(OffsetInteger{-1,UInt32}(0x0000003e), OffsetInteger{-1,UInt32}(0x0000003d), OffsetInteger{-1,UInt32}(0x0000003c)), TriangleFace(OffsetInteger{-1,UInt32}(0x0000003c), OffsetInteger{-1,UInt32}(0x0000003b), OffsetInteger{-1,UInt32}(0x0000003a)), TriangleFace(OffsetInteger{-1,UInt32}(0x0000003a), OffsetInteger{-1,UInt32}(0x00000039), OffsetInteger{-1,UInt32}(0x00000038)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000038), OffsetInteger{-1,UInt32}(0x00000037), OffsetInteger{-1,UInt32}(0x00000036)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000036), OffsetInteger{-1,UInt32}(0x00000035), OffsetInteger{-1,UInt32}(0x00000034)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000034), OffsetInteger{-1,UInt32}(0x00000033), OffsetInteger{-1,UInt32}(0x00000032)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000032), OffsetInteger{-1,UInt32}(0x00000031), OffsetInteger{-1,UInt32}(0x00000030)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000002f), OffsetInteger{-1,UInt32}(0x0000002e)), TriangleFace(OffsetInteger{-1,UInt32}(0x0000002e), OffsetInteger{-1,UInt32}(0x0000002d), OffsetInteger{-1,UInt32}(0x0000002c))  …  TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000006b), OffsetInteger{-1,UInt32}(0x0000006c)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000074), OffsetInteger{-1,UInt32}(0x00000000), OffsetInteger{-1,UInt32}(0x00000030)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000006c), OffsetInteger{-1,UInt32}(0x0000006d)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000073), OffsetInteger{-1,UInt32}(0x00000074), OffsetInteger{-1,UInt32}(0x00000030)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000006d), OffsetInteger{-1,UInt32}(0x0000006e)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000072), OffsetInteger{-1,UInt32}(0x00000073), OffsetInteger{-1,UInt32}(0x00000030)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000006e), OffsetInteger{-1,UInt32}(0x0000006f)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000071), OffsetInteger{-1,UInt32}(0x00000072), OffsetInteger{-1,UInt32}(0x00000030)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000030), OffsetInteger{-1,UInt32}(0x0000006f), OffsetInteger{-1,UInt32}(0x00000070)), TriangleFace(OffsetInteger{-1,UInt32}(0x00000070), OffsetInteger{-1,UInt32}(0x00000071), OffsetInteger{-1,UInt32}(0x00000030))])
Stacktrace:
    Function         Module  Signature
    ────────         ──────  ─────────
[1] top-level scope
REPL[13]:1
```