### PR TITLE
Add GeometryBasics compat, update version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "EarCut"
 uuid = "5160dea5-cc57-53b0-be5f-ac191989508a"
-version = "2.0.0"
+version = "2.0.1"
 
 [deps]
 EarCut_jll = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
@@ -8,6 +8,7 @@ GeometryBasics = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
 
 [compat]
 julia = "1.3"
+GeometryBasics = "0.1, 0.2, 0.3, 0.4"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
It looks like the General registry has capped the GeometryBasics version to 0.3.13 in its internal compat files.  This commit specifies the compat so that we can get EarCut working with newer versions of GeometryBasics.